### PR TITLE
Update backend docker file to build the jar file

### DIFF
--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -1,8 +1,21 @@
-FROM openjdk:17-jdk-slim AS build
+FROM maven:3.8.4-openjdk-17 AS build
 
 WORKDIR /app
 
-COPY target/project-zomboid-mod-manager-0.0.1-SNAPSHOT.jar app.jar
+# Kopiere die pom.xml und src Dateien
+COPY pom.xml .
+COPY src ./src
+
+# Führe Maven Build aus
+RUN mvn clean install -DskipTests
+
+# Zweiter Stage für den Runtime Container
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+# Kopiere nur das gebaute JAR aus dem Build-Stage
+COPY --from=build /app/target/project-zomboid-mod-manager-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     build:


### PR DESCRIPTION
I updated the docker file so that the jar file is getting build inside the container in the build layer instead of copying it from the outside.

Here is the proof that `docker compose build` is working as intended

![image](https://github.com/user-attachments/assets/85b7d88d-f139-496c-9f72-a1fd954c88db)

`docker compose up` starts both container as intended

![image](https://github.com/user-attachments/assets/55c1ded8-243b-432f-840a-fe035b5e6b3f)

And the backend is reachable 

![image](https://github.com/user-attachments/assets/642906b4-0a7a-4ee2-b8a3-2e4fba54e294)
