### PR TITLE
Update meta tags, add a correct title and description

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A web-based tool to help manage Project Zomboid mods"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -33,7 +33,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Project Zomboid Mod Manager</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
The page now has a correct title and a speaking description 
![image](https://github.com/user-attachments/assets/5dfc03f3-d71a-4cba-8c30-90e1589b9d12)
